### PR TITLE
🔒️ Access control fixes

### DIFF
--- a/bottle_breaker/access_control.py
+++ b/bottle_breaker/access_control.py
@@ -99,7 +99,7 @@ class Users(BaseDB):
             self.HASHING_ITERATIONS,
         )
 
-        return hashed_password == user_hash
+        return secrets.compare_digest(hashed_password, user_hash)
 
 
 class LoginForm(FlaskForm):

--- a/bottle_breaker/access_control.py
+++ b/bottle_breaker/access_control.py
@@ -5,7 +5,6 @@ import secrets
 from datetime import datetime
 from hashlib import pbkdf2_hmac
 from sqlite3 import IntegrityError
-from typing import Optional
 
 from flask_login import AnonymousUserMixin, UserMixin
 from flask_wtf import FlaskForm
@@ -50,14 +49,11 @@ class Users(BaseDB):
     def add_user(
         self,
         username: str,
-        password: Optional[str] = None,
+        password: str,
     ) -> str:
         """Add a new user, returning a temporary password or a chosen password."""
 
         salt = secrets.token_hex(32)
-
-        if password is None:
-            password = secrets.token_hex(4)
 
         hashed_password = pbkdf2_hmac(
             "sha256", password.encode(), salt.encode(), self.HASHING_ITERATIONS

--- a/bottle_breaker/access_control.py
+++ b/bottle_breaker/access_control.py
@@ -51,7 +51,7 @@ class Users(BaseDB):
         username: str,
         password: str,
     ) -> str:
-        """Add a new user, returning a temporary password or a chosen password."""
+        """Add a new user, returning 'Success' or an Error"""
 
         salt = secrets.token_hex(32)
 


### PR DESCRIPTION
- Drop `Optional[str]` type from password field in `add_user` function: I'm not supporting temporary passwords elsewhere in the application and do not plan to anytime soon.
- Replace `==` with `secrets.compare_digest(hashed_password, user_hash)`

The `verify_user` function is not robust to timing attacks against whether a `username` *exists*. But remaining steps for (1) selecting hash/salt, (2) hashing the input, (3) using a constant-time algorithm to check equality should be better practice overall.